### PR TITLE
fix: 修复关闭按钮无法正常关闭窗口的问题

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,10 +41,9 @@ fn show_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
 pub fn run() {
     tauri::Builder::default()
         .on_window_event(|window, event| {
-            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+            if let tauri::WindowEvent::CloseRequested { .. } = event {
                 if window.label() == "main" {
-                    let _ = window.hide();
-                    api.prevent_close();
+                    // 直接关闭窗口，不隐藏到系统托盘
                 }
             }
         })


### PR DESCRIPTION
## 问题描述
点击右上角关闭按钮（叉号）时，窗口被隐藏到系统托盘而非真正关闭。第二次打开窗口后再点击关闭按钮时失效，只能通过任务管理器结束进程。

## 根因
 中使用了  + ，让关闭操作变成了隐藏窗口。

## 修复
移除  和 ，点击关闭按钮直接关闭窗口。如需后台运行或彻底退出，可通过系统托盘右键菜单操作。