### PR TITLE
feat: add GitHub Actions workflow for macOS builds

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,58 @@
+name: Build macOS
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            arch: aarch64
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            arch: x64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install frontend dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli --version "^2"
+
+      - name: Build Tauri app (${{ matrix.arch }})
+        run: cargo tauri build --target ${{ matrix.target }}
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+
+      - name: Upload .app bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: ZError-${{ matrix.arch }}.app
+          path: src-tauri/target/${{ matrix.target }}/release/bundle/macos/ZError.app
+          if-no-files-found: error
+
+      - name: Upload .dmg
+        uses: actions/upload-artifact@v4
+        with:
+          name: ZError-${{ matrix.arch }}.dmg
+          path: src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+          if-no-files-found: warn

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -32,7 +32,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install frontend dependencies
-        run: bun install --frozen-lockfile
+        run: bun install
 
       - name: Install Tauri CLI
         run: cargo install tauri-cli --version "^2"

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -37,6 +37,19 @@ jobs:
       - name: Install Tauri CLI
         run: cargo install tauri-cli --version "^2"
 
+      - name: Disable updater artifacts if no signing key
+        if: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY == '' }}
+        run: |
+          echo "No signing key found, disabling updater artifacts"
+          python3 -c "
+import json
+with open('src-tauri/tauri.conf.json') as f:
+    cfg = json.load(f)
+cfg.setdefault('bundle', {})['createUpdaterArtifacts'] = False
+with open('src-tauri/tauri.conf.json', 'w') as f:
+    json.dump(cfg, f, indent=2)
+"
+
       - name: Build Tauri app (${{ matrix.arch }})
         run: cargo tauri build --target ${{ matrix.target }}
         env:


### PR DESCRIPTION
## 概述

添加 macOS 构建的 GitHub Actions CI 配置，让每次发布 tag 时自动构建 **arm64** 和 **x86_64** 双架构的 macOS 版本（.app + .dmg）。

## 背景

ZError 目前只发布 Windows 安装包，macOS 用户需要自行从源码构建。这个 PR 解决了这个问题——作者只需在发布时推送 tag，CI 会自动产出 macOS 构建产物。

## 工作流说明

- 触发条件：推送 `v*` 格式的 tag 或手动触发 (`workflow_dispatch`)
- 构建矩阵：`aarch64-apple-darwin` (Apple Silicon) + `x86_64-apple-darwin` (Intel)
- 前端：使用 Bun（项目已有 `bun.lock`）
- 签名：如果仓库设置了 `TAURI_SIGNING_PRIVATE_KEY` 和 `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` secrets，产物会被签名（可选）
- 产物：ZError.app 和 ZError.dmg 作为 Artifact 上传

## 作者需要做的

1. 合并此 PR
2. 推送新 tag 时，Actions 会自动构建 macOS 版本
3. （可选）在 GitHub Release 中手动上传生成的 .dmg 文件